### PR TITLE
[SmartSwitch] Force sync DPU time during bfb install

### DIFF
--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -279,11 +279,15 @@ bfb_install_call() {
     fi
     remove_cx_pci_device "$rshim" "$dpu"
 
-    # Construct bfb-install command
-    local cmd="timeout ${timeout_secs}s bfb-install -b $bfb -r $rshim"
+    # Create config file with NPU time for DPU time synchronization
+    local config_file=$(mktemp "${WORK_DIR}/bf_cfg.XXXXX")
     if [ -n "$appendix" ]; then
-        cmd="$cmd -c $appendix"
+        cat "$appendix" > "$config_file"
     fi
+    echo "NPU_TIME=$(date +%s)" >> "$config_file"
+
+    # Construct bfb-install command
+    local cmd="timeout ${timeout_secs}s bfb-install -b $bfb -r $rshim -c $config_file"
     log_info "Installing bfb image on DPU connected to $rshim using $cmd"
 
     # Run installation with progress monitoring

--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -311,6 +311,8 @@ bfb_install_call() {
         cat "$result_file"
     fi
 
+    rm -f "$config_file"
+
     # Stop rshim application and reset DPU
     stop_rshim_daemon "$rid"
     log_info "$rid: Resetting DPU $dpu"

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -101,6 +101,10 @@ fi
 if [ -n "$NPU_TIME" ]; then
 	log "Setting system time from NPU: $NPU_TIME"
 	date -s "@$NPU_TIME"
+	log "System time set to: $(date)"
+	if [ -e /dev/rtc0 ]; then
+		hwclock --systohc --utc
+		log "Hardware clock synced from system time"
 fi
 
 # Flags that can be overwritten by the bf.cfg

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -98,6 +98,11 @@ if [ -e /etc/bf.cfg ]; then
 	. /etc/bf.cfg
 fi
 
+if [ -n "$NPU_TIME" ]; then
+	log "Setting system time from NPU: $NPU_TIME"
+	date -s "@$NPU_TIME"
+fi
+
 # Flags that can be overwritten by the bf.cfg
 declare -r SKIP_FIRMWARE_UPGRADE="${SKIP_FIRMWARE_UPGRADE:-false}"
 declare -r FORCE_FW_CONFIG_RESET="${FORCE_FW_CONFIG_RESET:-false}"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

