### PR TITLE
[DPU] Add support for HA Set Counters

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -37,7 +37,7 @@ def enable_rates():
 def enable_counters():
     db = swsscommon.ConfigDBConnector()
     db.connect()
-    dpu_counters = ["ENI","DASH_METER"]
+    dpu_counters = ["ENI","DASH_METER", "CP_DATA_CHANNEL", "BULK_SYNC"]
 
     platform_info = device_info.get_platform_info(db)
     if platform_info.get('switch_type') == 'dpu':

--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -37,7 +37,7 @@ def enable_rates():
 def enable_counters():
     db = swsscommon.ConfigDBConnector()
     db.connect()
-    dpu_counters = ["ENI","DASH_METER", "CP_DATA_CHANNEL", "BULK_SYNC"]
+    dpu_counters = ["ENI","DASH_METER", "HA_SET"]
 
     platform_info = device_info.get_platform_info(db)
     if platform_info.get('switch_type') == 'dpu':

--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -37,7 +37,7 @@ def enable_rates():
 def enable_counters():
     db = swsscommon.ConfigDBConnector()
     db.connect()
-    dpu_counters = ["ENI","DASH_METER", "HA_SET"]
+    dpu_counters = ["ENI","DASH_METER"]
 
     platform_info = device_info.get_platform_info(db)
     if platform_info.get('switch_type') == 'dpu':

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1558,6 +1558,14 @@
                 "FLEX_COUNTER_STATUS": "enable",
                 "POLL_INTERVAL": "10000"
             },
+            "CP_DATA_CHANNEL": {
+                "FLEX_COUNTER_STATUS": "enable",
+                "POLL_INTERVAL": "10000"
+            },
+            "BULK_SYNC": {
+                "FLEX_COUNTER_STATUS": "enable",
+                "POLL_INTERVAL": "10000"
+            },
             "SRV6": {
                 "FLEX_COUNTER_STATUS": "enable",
                 "POLL_INTERVAL": "10000"

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1558,11 +1558,7 @@
                 "FLEX_COUNTER_STATUS": "enable",
                 "POLL_INTERVAL": "10000"
             },
-            "CP_DATA_CHANNEL": {
-                "FLEX_COUNTER_STATUS": "enable",
-                "POLL_INTERVAL": "10000"
-            },
-            "BULK_SYNC": {
+            "HA_SET": {
                 "FLEX_COUNTER_STATUS": "enable",
                 "POLL_INTERVAL": "10000"
             },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -17,6 +17,14 @@
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 10000
                 },
+                "CP_DATA_CHANNEL": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "BULK_SYNC": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
                 "PFCWD": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -17,11 +17,7 @@
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 10000
                 },
-                "CP_DATA_CHANNEL": {
-                    "FLEX_COUNTER_STATUS": "enable",
-                    "POLL_INTERVAL": 10000
-                },
-                "BULK_SYNC": {
+                "HA_SET": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 10000
                 },

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -105,21 +105,8 @@ module sonic-flex_counter {
                 }
             }
 
-            container CP_DATA_CHANNEL {
-                /* CP_DATA_CHANNEL_STAT_COUNTER_FLEX_COUNTER_GROUP */
-                leaf FLEX_COUNTER_STATUS {
-                    type flex_status;
-                }
-                leaf FLEX_COUNTER_DELAY_STATUS {
-                    type flex_delay_status;
-                }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
-                }
-            }
-
-            container BULK_SYNC {
-                /* BULK_SYNC_COUNTER */
+            container HA_SET {
+                /* HA_SET_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -105,6 +105,32 @@ module sonic-flex_counter {
                 }
             }
 
+            container CP_DATA_CHANNEL {
+                /* CP_DATA_CHANNEL_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
+
+            container BULK_SYNC {
+                /* BULK_SYNC_COUNTER */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
+
             container PFCWD {
                 /* PFC_WD_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {


### PR DESCRIPTION
**What I did**

1. Add support for DASH HA Set Counters
2. Updated the FlexCounter Yang model

Adds support for ha-set counters. Adds a dashhacounter class that inherits from dashcounter for displaying counters defined in _sai_ha_set_stat_t. Also refactored the existing code to keep the same level of access to dashcounter methods by moving it to its own files.

**Why I did it**

**How I verified it**

```
root@sonic:/home/admin# sonic-db-cli FLEX_COUNTER_DB HGETALL FLEX_COUNTER_GROUP_TABLE:HA_SET_STAT_COUNTER
{'POLL_INTERVAL': '10000', 'STATS_MODE': 'STATS_MODE_READ', 'FLEX_COUNTER_STATUS': 'enable'}
root@sonic:/home/admin# sonic-db-cli COUNTERS_DB HGETALL COUNTERS_HA_SET_NAME_MAP
{'haset0_0': 'oid:0x1100800000001e'}

In sairedis.rec
2026-02-18.16:39:42.679404|c|SAI_OBJECT_TYPE_HA_SET:oid:0x1100800000001e|SAI_HA_SET_ATTR_LOCAL_IP=20.0.200.3|SAI_HA_SET_ATTR_PEER_IP=20.0.201.3|SAI_HA_SET_ATTR_CP_DATA_CHANNEL_PORT=6000|SAI_HA_SET_ATTR_DP_CHANNEL_DST_PORT=7000|SAI_HA_SET_ATTR_DP_CHANNEL_MIN_SRC_PORT=7001|SAI_HA_SET_ATTR_DP_CHANNEL_MAX_SRC_PORT=7010|SAI_HA_SET_ATTR_DP_CHANNEL_PROBE_INTERVAL_MS=500|SAI_HA_SET_ATTR_DP_CHANNEL_PROBE_FAIL_THRESHOLD=5
2026-02-18.16:39:42.683256|p|HA_SET_STAT_COUNTER:oid:0x1100800000001e|HA_SET_COUNTER_ID_LIST=SAI_HA_SET_STAT_BULK_SYNC_FLOW_RECEIVED,SAI_HA_SET_STAT_BULK_SYNC_MESSAGE_SENT,SAI_HA_SET_STAT_BULK_SYNC_MESSAGE_RECEIVED,SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_REJECTED,SAI_HA_SET_STAT_DP_PROBE_REQ_RX_BYTES,SAI_HA_SET_STAT_BULK_SYNC_FLOW_SENT,SAI_HA_SET_STAT_DP_PROBE_REQ_TX_BYTES,SAI_HA_SET_STAT_DP_PROBE_REQ_RX_PACKETS,SAI_HA_SET_STAT_DP_PROBE_ACK_RX_PACKETS,SAI_HA_SET_STAT_DP_PROBE_REQ_TX_PACKETS,SAI_HA_SET_STAT_BULK_SYNC_MESSAGE_SEND_FAILED,SAI_HA_SET_STAT_DP_PROBE_ACK_TX_PACKETS,SAI_HA_SET_STAT_DP_PROBE_ACK_TX_BYTES,SAI_HA_SET_STAT_DP_PROBE_ACK_RX_BYTES,SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_RECEIVED,SAI_HA_SET_STAT_DP_PROBE_FAILED,SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_ATTEMPTED,SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_SUCCEEDED,SAI_HA_SET_STAT_CP_DATA_CHANNEL_TIMEOUT_COUNT,SAI_HA_SET_STAT_CP_DATA_CHANNEL_CONNECT_FAILED
```

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [X] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[DPU] Add support for HA Set Counters

