### PR TITLE
Create clean Rshim version using templates

### DIFF
--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -44,7 +44,7 @@ COMMANDS_FOR_ACTUAL = {
     "SAI_API_HEADERS": [["docker", "exec", "syncd", "dpkg", "-s", "mlnx-sai"], "X-Sai-Headers-Version: ([0-9.]+)"],
     "FW": [["mlxfwmanager", "--query"], "FW * [0-9]{2}\\.([0-9.]*)"],
     "KERNEL": [["uname", "-r"], "(.*)-[a-z0-9]+$"],
-    "RSHIM": [["dpkg", "-l"], ["grep", "rshim "], "rshim *([0-9.-]*)"]
+    "RSHIM": [["dpkg", "-l"], ["grep", "rshim "], "rshim *([0-9.]*)"]
 }
 
 UNAVAILABLE_COMPILED_VERSIONS = {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently the RSHIM version returned by get_component_versions.py includes information on the date it was compiled and the BFSOC version it was compiled with, as well as the actual version. This is not necessary for customers and will confuse them when debugging. This PR populated only the actual RSHIM version.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

