### PR TITLE
[SmartSwitch] [DPU] Support maximum dash configuration size

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -26,7 +26,7 @@ if [[ x"${LOCALHOST_SWITCHTYPE}" == x"chassis-packet" ]]; then
     ORCHAGENT_ARGS+="-b 128 "
 elif [[ x"$LOCALHOST_SWITCHTYPE" == x"dpu" ]]; then
     # To handle high volume of objects in DPU
-    ORCHAGENT_ARGS+="-b 65536 "
+    ORCHAGENT_ARGS+="-b 131072 "
 else
     # Set orchagent pop batch size to 1024
     ORCHAGENT_ARGS+="-b 1024 "
@@ -36,7 +36,7 @@ fi
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
 if [ "$LOCALHOST_SWITCHTYPE" == "dpu" ]; then
-    ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
+    ORCHAGENT_ARGS+="-z zmq_sync -k 131072 "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
 fi

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -88,7 +88,7 @@ fi
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    TELEMETRY_ARGS+=" -zmq_port=8100"
+    TELEMETRY_ARGS+=" -zmq_port=8100 -max_recv_msg_size=131072 -max_send_msg_size=131072"
 fi
 
 # Add VRF parameter when mgmt-vrf enabled


### PR DESCRIPTION

#### Why I did it
SONiC Orchagent zmq does not currently support a large enough buffer size to handle the max dash scale config on DPU. sonic-gnmi also does not support a large enough send and recv message sizes to handle the max dash scale.

#### How I did it
I increased orchagent zmq buffer to 131 MB and increased the sonic-gnmi max recv and send message sizes to 125k.

#### How to verify it
Send the maximum dash scale config in a test and confirm config is applied.